### PR TITLE
BLT-14: Upgrade eslint to v1.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 rules:
-    indent: 4
+    "indent": 2
     brace-style: [2, "1tbs"]
     comma-style: [2, "last"]
     default-case: 2
@@ -8,12 +8,11 @@ rules:
     no-floating-decimal: 2
     no-nested-ternary: 2
     no-undefined: 2
-    quotes: "single"
+    quotes: [2, 'single']
     radix: 2
     space-after-keywords: [2, "always"]
     space-before-blocks: 2
-    spaced-line-comment: [2, "always", { exceptions: ["-"]}]
+    spaced-comment: [2, "always", { exceptions: ["-"]}]
     strict: [2, "global"]
-    global-strict: [2, "always"]
     valid-jsdoc: [2, { prefer: { "return": "returns"}}]
     wrap-iife: [2, "inside"]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-autoprefixer": "^2.0.0",
     "gulp-changed": "^1.1.0",
     "gulp-combine-mq": "^0.4.0",
-    "gulp-eslint": "^0.12.0",
+    "gulp-eslint": "^1.0.0",
     "gulp-imagemin": "^2.0.0",
     "gulp-jscs": "^1.3.1",
     "gulp-load-plugins": "^0.8.0",


### PR DESCRIPTION
- Update package.json
- Redefine lint rules based on v1

Pre version 1 there were bugs with correctly linting shadowing. V1 brings some stability to the table.
